### PR TITLE
clear NSMainNibFile entry in Info.plist

### DIFF
--- a/generators/app/templates/hooks/after_prepare/update_platform_config.js
+++ b/generators/app/templates/hooks/after_prepare/update_platform_config.js
@@ -353,7 +353,8 @@ var platformConfig = (function () {
       tempInfoPlist = plist.build(infoPlist);
 
       // remove NSMainNibFile entry that crashes the App
-      tempInfoPlist = tempInfoPlist.replace(/<string>NSMainNibFile~ipad<\/string>/g, '<string></string>');
+      tempInfoPlist = tempInfoPlist.replace(/<key>NSMainNibFile~ipad<\/key>/g, '');
+      tempInfoPlist = tempInfoPlist.replace(/<key>NSMainNibFile<\/key>/g, '');
 
       tempInfoPlist = tempInfoPlist.replace(/<string>[\s\r\n]*<\/string>/g, '<string></string>');
       fs.writeFileSync(targetFile, tempInfoPlist, 'utf-8');

--- a/generators/app/templates/hooks/after_prepare/update_platform_config.js
+++ b/generators/app/templates/hooks/after_prepare/update_platform_config.js
@@ -351,6 +351,10 @@ var platformConfig = (function () {
       });
 
       tempInfoPlist = plist.build(infoPlist);
+
+      // remove NSMainNibFile entry that crashes the App
+      tempInfoPlist = tempInfoPlist.replace(/<string>NSMainNibFile~ipad<\/string>/g, '<string></string>');
+
       tempInfoPlist = tempInfoPlist.replace(/<string>[\s\r\n]*<\/string>/g, '<string></string>');
       fs.writeFileSync(targetFile, tempInfoPlist, 'utf-8');
     }


### PR DESCRIPTION
This fixes an invalid entry in the Info.plist (https://forum.ionicframework.com/t/xcode-main-interface-nsmainnibfile-ipad/66942). 
NSMainNibFiles define which orientation the App is allowed to run. Nowadays this is set in the UISupportedInterfaceOrientations entry in the Info.plist. The App crashes if you have both in your Info.plist:

```
    NSMainNibFile = NSMainNibFile~ipad
    UISupportedInterfaceOrientations~ipad = Array {
        UIInterfaceOrientationLandscapeLeft
        UIInterfaceOrientationLandscapeRight
        UIInterfaceOrientationPortrait
        UIInterfaceOrientationPortraitUpsideDown
    }
```

The hook removes both NSMainNibFile entries completely.