### PR TITLE
Fix for Windows OS incompatibility when copying resources

### DIFF
--- a/generators/app/templates/gulp/cordova.js
+++ b/generators/app/templates/gulp/cordova.js
@@ -35,13 +35,18 @@ gulp.task('clean-res', function () {
   return gulp.src('res/*/current/*')
     .pipe(vinylPaths(del));
 });
+
 gulp.task('resources', ['clean-res'], function () {
   var setFolder = options.res || 'default';
+  var slash = '/';
 
   var resourceFiles = 'res/*/' + setFolder + '/**/*';
   return gulp.src(resourceFiles)
     .pipe($.rename(function (path) {
-      path.dirname = path.dirname.replace('/' + setFolder, '/current');
+      if (path.dirname.search(/\\/ig) > -1) {
+        slash = '\\';
+      }
+      path.dirname = path.dirname.replace(slash + setFolder, slash + 'current');
     }))
     .pipe(gulp.dest('res'));
 });


### PR DESCRIPTION
Since Windows paths contain backslashes and not slashes, the resource task was failing on all windows machines. This PR fixes the issue.