### PR TITLE
Updated travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,9 @@ node_js:
   - "4"
 notifications:
   email: false
-  slack:
-    rooms:
-      - m-wayteam:id3DFokHndVEGtjOM9fR0DVj#generator-m-services
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: change  # options: [always|never|change] default: always
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/87130ded51c12384d4e7
+      - https://mattermost.mwaysolutions.com/hooks/7b794wboitdaxrzjkxcjt3enjr
     on_success: always  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always


### PR DESCRIPTION
- removed posting to the old slack channel
- added a mattermost webhook, which should in the channel `generator-m-services`

as described in issue #495 