### PR TITLE
fix missing karma jasmine dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "gulp-mocha": "^3.0.1",
     "gulp-nsp": "^2.4.2",
     "gulp-plumber": "^1.0.1",
+    "jasmine-core": "^2.5.2",
     "yeoman-assert": "^3.0.0",
     "yeoman-test": "^1.0.0"
   }


### PR DESCRIPTION
This fixes the warning of a missing dependency `warning "karma-jasmine@1.1.0" has unmet peer dependency "jasmine-core@*".` when running `yarn` on a new generator-m project.